### PR TITLE
Update win_malware_rcl.txt

### DIFF
--- a/rootcheck/ossec/win_malware_rcl.txt
+++ b/rootcheck/ossec/win_malware_rcl.txt
@@ -37,7 +37,7 @@ f:%WINDIR%\System32\wgareg.exe;
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\wgareg;
 
 # http://www.f-prot.com/virusinfo/descriptions/sober_j.html
-[Sober Worm] {PCI_DSS: 11.4} [any] []
+[Sober Worm {PCI_DSS: 11.4}] [any] []
 f:%WINDIR%\System32\nonzipsr.noz;
 f:%WINDIR%\System32\clonzips.ssc;
 f:%WINDIR%\System32\clsobern.isc;


### PR DESCRIPTION
Fix typo in Sober Worm entry where the closing square brace came before the PCI tag instead of after it.  This was causing Windows rootchecks to fail because it couldn't read this file.